### PR TITLE
Add CLI option to only analyze retained memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ To then analyse the profile, run the `heap-profiler` command against the directo
 Note that on large applications this can take a while, but if you are profiling a production
 application, you can download the profile directory and do the analysis on another machine.
 
+### Options
+
+```
+Usage: heap-profiler <directory_or_heap_dump> OPTIONS"
+
+OPTIONS
+
+    -r, --retained-only              Only compute report for memory retentions.
+        --batch-size SIZE            Sets the simdjson parser batch size. It must be larger than the largest JSON document in the heap dump, and defaults to 10MB.
+```
+
+
+
 ```bash
 $ heap-profiler path/to/report/directory
       Total allocated: 3.72 kB (36 objects)

--- a/lib/heap_profiler/cli.rb
+++ b/lib/heap_profiler/cli.rb
@@ -27,7 +27,11 @@ module HeapProfiler
 
     def print_report(path)
       results = if File.directory?(path)
-        DiffResults.new(path)
+        if @retained_only
+          DiffResults.new(path, ["retained"])
+        else
+          DiffResults.new(path)
+        end
       else
         HeapResults.new(path)
       end
@@ -70,6 +74,10 @@ module HeapProfiler
         opts.separator ""
         opts.separator "GLOBAL OPTIONS"
         opts.separator ""
+
+        opts.on('-r', '--retained-only', 'Only compute report for memory retentions.') do
+          @retained_only = true
+        end
 
         help = <<~EOS
           Sets the simdjson parser batch size. It must be larger than the largest JSON document in the


### PR DESCRIPTION
Usually `allocated.heap` is larger than `retained.heap`. Occasionally, when the subject of analysis are the memory retentions, it is cumbersome and slow to compute the diff for the memory allocations.

Introduces a flag `-r` which runs for only retained memory.

---

I can cut a release in a following commit with the version bumped.