### PR TITLE
Be able to limit output to a number of entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ application, you can download the profile directory and do the analysis on anoth
 ### Options
 
 ```
-Usage: heap-profiler <directory_or_heap_dump> OPTIONS"
+Usage: heap-profiler <directory_or_heap_dump> OPTIONS
 
 OPTIONS
 
     -r, --retained-only              Only compute report for memory retentions.
+    -m, --max=NUM                    Max number of entries to output. (Defaults to 50)
         --batch-size SIZE            Sets the simdjson parser batch size. It must be larger than the largest JSON document in the heap dump, and defaults to 10MB.
 ```
 

--- a/lib/heap_profiler/analyzer.rb
+++ b/lib/heap_profiler/analyzer.rb
@@ -143,12 +143,13 @@ module HeapProfiler
           end
         end
 
-        def top_n(_max)
+        def top_n(max)
           values = @locations_counts.values
           values.sort! do |a, b|
             cmp = b.count <=> a.count
             cmp == 0 ? b.location <=> a.location : cmp
           end
+          values.take(max)
         end
       end
 

--- a/lib/heap_profiler/cli.rb
+++ b/lib/heap_profiler/cli.rb
@@ -79,6 +79,11 @@ module HeapProfiler
           @retained_only = true
         end
 
+        HeapProfiler::AbstractResults.top_entries_count = 50
+        opts.on("-m", "--max=NUM", Integer, "Max number of entries to output. (Defaults to 50)") do |arg|
+          HeapProfiler::AbstractResults.top_entries_count = arg
+        end
+
         help = <<~EOS
           Sets the simdjson parser batch size. It must be larger than the largest JSON document in the
           heap dump, and defaults to 10MB.

--- a/lib/heap_profiler/results.rb
+++ b/lib/heap_profiler/results.rb
@@ -19,6 +19,11 @@ module HeapProfiler
 
     attr_reader :types, :dimensions
 
+    @top_entries_count = 50
+    class << self
+      attr_accessor :top_entries_count
+    end
+
     def initialize(*, **)
       raise NotImplementedError
     end
@@ -95,7 +100,7 @@ module HeapProfiler
 
     def dump_data(io, dimensions, metric, grouping, options)
       print_title io, "#{metric} by #{grouping}"
-      data = dimensions[grouping].top_n(metric, options.fetch(:top, 50))
+      data = dimensions[grouping].top_n(metric, AbstractResults.top_entries_count)
 
       scale_data = metric == "memory" && options[:scale_bytes]
       normalize_paths = options[:normalize_paths]
@@ -112,7 +117,7 @@ module HeapProfiler
     def dump_strings(io, dimensions, options)
       normalize_paths = options[:normalize_paths]
       scale_data = options[:scale_bytes]
-      top = options.fetch(:top, 50)
+      top = AbstractResults.top_entries_count
 
       print_title(io, "String Report")
 
@@ -176,7 +181,7 @@ module HeapProfiler
 
     def dump_data(io, dimensions, type, metric, grouping, options)
       print_title io, "#{type} #{metric} by #{grouping}"
-      data = dimensions[type][grouping].top_n(metric, options.fetch(:top, 50))
+      data = dimensions[type][grouping].top_n(metric, AbstractResults.top_entries_count)
 
       scale_data = metric == "memory" && options[:scale_bytes]
       normalize_paths = options[:normalize_paths]
@@ -193,7 +198,7 @@ module HeapProfiler
     def dump_strings(io, dimensions, type, options)
       normalize_paths = options[:normalize_paths]
       scale_data = options[:scale_bytes]
-      top = options.fetch(:top, 50)
+      top = AbstractResults.top_entries_count
 
       print_title(io, "#{type.capitalize} String Report")
 


### PR DESCRIPTION
This is the same behavior as `memory_profiler`. We want to be able to limit the number of entries on the output.

The only issue I see is one arguments limit the number of string to display + the number of location where the string was allocated. Maybe it is a little bit misleading but the main goal is to limit size of the output. So it is probably ok.

Also tell me if you want some tests. 