### PR TITLE
Allow to ship this gem with precompiled binaries

### DIFF
--- a/.github/workflows/cibuildgem.yaml
+++ b/.github/workflows/cibuildgem.yaml
@@ -1,0 +1,88 @@
+name: "Package and release gems with precompiled binaries"
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "If the whole build passes on all platforms, release the gems on RubyGems.org"
+        required: false
+        type: boolean
+        default: false
+  push:
+
+jobs:
+  compile:
+    timeout-minutes: 20
+    name: "Cross compile the gem on different ruby versions"
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04", "ubuntu-22.04-arm", "macos-15-intel"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.1.7"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "compile"
+  test:
+    timeout-minutes: 20
+    name: "Run the test suite"
+    needs: compile
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04", "ubuntu-22.04-arm", "macos-15-intel"]
+        rubies: ["3.1", "3.2", "3.3", "3.4"]
+        type: ["cross", "native"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "${{ matrix.rubies }}"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "test_${{ matrix.type }}"
+  install:
+    timeout-minutes: 5
+    name: "Verify the gem can be installed"
+    needs: test
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04", "ubuntu-22.04-arm", "macos-15-intel"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.4.7"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "install"
+  release:
+    permissions:
+      id-token: write
+      contents: read
+    timeout-minutes: 5
+    if: ${{ inputs.release }}
+    name: "Release all gems with RubyGems"
+    needs: install
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.4.7"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "release"

--- a/.github/workflows/cibuildgem.yaml
+++ b/.github/workflows/cibuildgem.yaml
@@ -7,8 +7,6 @@ on:
         required: false
         type: boolean
         default: false
-  push:
-
 jobs:
   compile:
     timeout-minutes: 20
@@ -69,6 +67,7 @@ jobs:
         with:
           step: "install"
   release:
+    environment: release
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/cibuildgem.yaml
+++ b/.github/workflows/cibuildgem.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-22.04", "ubuntu-22.04-arm", "macos-15-intel"]
-        rubies: ["3.1", "3.2", "3.3", "3.4"]
+        rubies: ["3.1", "3.2", "3.3", "3.4", "4.0"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
     steps:
@@ -61,7 +61,7 @@ jobs:
       - name: "Setup Ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.4.7"
+          ruby-version: "4.0"
       - name: "Run cibuildgem"
         uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
         with:
@@ -80,7 +80,7 @@ jobs:
       - name: "Setup Ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.4.7"
+          ruby-version: "4.0"
       - name: "Run cibuildgem"
         uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', '4.0' ]
     name: Ruby ${{ matrix.ruby }} Tests
     steps:
       - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     unicode-emoji (4.1.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-23
   arm64-darwin-25
   x86_64-darwin-20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     stackprof (0.2.27)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
 
 PLATFORMS
   aarch64-linux
@@ -52,6 +52,7 @@ PLATFORMS
   arm64-darwin-25
   x86_64-darwin-20
   x86_64-darwin-22
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/heap_profiler/parser.rb
+++ b/lib/heap_profiler/parser.rb
@@ -74,5 +74,10 @@ module HeapProfiler
       end
     end
   end
-  require "heap_profiler/heap_profiler"
+
+  begin
+    require "heap_profiler/#{RUBY_VERSION[/^\d+\.\d+/]}/heap_profiler"
+  rescue LoadError
+    require "heap_profiler/heap_profiler"
+  end
 end


### PR DESCRIPTION
TL;DR I'd like to propose releasing this gem with precompiled binaries built for different platforms and different ABI version (fat gem).

This is an example of the workflow that will run once we cut a release https://github.com/Shopify/heap-profiler/actions/runs/20088673453

I'm currently working on a tool to help the Ruby community ship gems with precompiled binaries with the intent to make `bundle install` much faster for everyone. The main bottleneck when installing gems in a project is the compilation of native extensions.

[cibuildgem](https://github.com/Shopify/cibuildgem) modestly tries to follow the same approach as what the python community did with [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/).

It works with a native compilation using CI runners (GitHub it the only supported vendor for now) and tries to be as easy to setup as possible.

The CI workflow in this commit was generated with the cibuildgem CLI which reads the gemspec and determine what ruby versions needs to be compiled and tested against.