### PR TITLE
Accept --(no-)color option for CLI to force (no)colorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Usage: heap-profiler <directory_or_heap_dump> OPTIONS
 OPTIONS
 
     -r, --retained-only              Only compute report for memory retentions.
+        --[no-]color                 Colorize the output. (Defaults to only when the output is a terminal)
     -m, --max=NUM                    Max number of entries to output. (Defaults to 50)
         --batch-size SIZE            Sets the simdjson parser batch size. It must be larger than the largest JSON document in the heap dump, and defaults to 10MB.
 ```

--- a/lib/heap_profiler/cli.rb
+++ b/lib/heap_profiler/cli.rb
@@ -44,7 +44,11 @@ module HeapProfiler
       else
         HeapResults.new(path)
       end
-      results.pretty_print(scale_bytes: true, normalize_paths: true)
+      options = { scale_bytes: true, normalize_paths: true }
+      # Only set `color_output` if it was explicitly requested, otherwise
+      # the results default to colorizing only when the output is a TTY.
+      options[:color_output] = @color_output unless @color_output.nil?
+      results.pretty_print(**options)
     end
 
     def clean_dump(path)
@@ -118,6 +122,11 @@ module HeapProfiler
 
         opts.on('-r', '--retained-only', 'Only compute report for memory retentions.') do
           @retained_only = true
+        end
+
+        help = 'Colorize the output. (Defaults to only when the output is a terminal)'
+        opts.on('--[no-]color', help) do |color|
+          @color_output = color
         end
 
         HeapProfiler::AbstractResults.top_entries_count = 50


### PR DESCRIPTION
The results classes already accept the option, we just need to pass it there from the CLI